### PR TITLE
[codex] Fix browser console warnings

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import "@fontsource-variable/rubik/index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "@/three/configureThree";
 import { App } from "@/app/App";
 import "@/styles.css";
 import "@/pwa/register";

--- a/src/pwa/register.ts
+++ b/src/pwa/register.ts
@@ -1,5 +1,5 @@
 import { registerSW } from "virtual:pwa-register";
-import { registerInstallPrompt, registerUpdateHandler, setNeedsRefresh, setOfflineReady, setOfflineStatus, type BeforeInstallPromptEvent } from "@/pwa/state";
+import { registerUpdateHandler, setNeedsRefresh, setOfflineReady, setOfflineStatus } from "@/pwa/state";
 
 const updateServiceWorker = registerSW({
   immediate: true,
@@ -20,10 +20,3 @@ setOfflineStatus(typeof navigator !== "undefined" ? navigator.onLine === false :
 
 window.addEventListener("online", () => setOfflineStatus(false));
 window.addEventListener("offline", () => setOfflineStatus(true));
-window.addEventListener("beforeinstallprompt", (event) => {
-  event.preventDefault();
-  registerInstallPrompt(event as BeforeInstallPromptEvent);
-});
-window.addEventListener("appinstalled", () => {
-  registerInstallPrompt(null);
-});

--- a/src/pwa/sw.ts
+++ b/src/pwa/sw.ts
@@ -9,7 +9,15 @@ const manifestEntries = self.__WB_MANIFEST as Array<{ url: string }>;
 const precacheName = "cubism-precache-v2";
 const runtimeName = "cubism-runtime-v2";
 const navigationCacheName = "cubism-navigation-v2";
-const precacheUrls = Array.from(new Set(["/", "/index.html", ...manifestEntries.map((entry) => entry.url)]));
+const precacheUrls = Array.from(
+  new Map(
+    ["/", "/index.html", ...manifestEntries.map((entry) => entry.url)].map((url) => {
+      const normalizedUrl = new URL(url, serviceWorkerSelf.location.origin);
+      const cacheKey = normalizedUrl.pathname === "/index.html" ? "/" : `${normalizedUrl.pathname}${normalizedUrl.search}`;
+      return [cacheKey, normalizedUrl.pathname + normalizedUrl.search] as const;
+    })
+  ).values()
+);
 const offlineDocument = `<!doctype html>
 <html lang="de">
   <head>

--- a/src/three/configureThree.ts
+++ b/src/three/configureThree.ts
@@ -1,0 +1,14 @@
+import { setConsoleFunction } from "three";
+
+const clockDeprecationMessage = "THREE.THREE.Clock: This module has been deprecated. Please use THREE.Timer instead.";
+
+setConsoleFunction((level, message, ...params) => {
+  if (level === "warn" && message === clockDeprecationMessage) {
+    return;
+  }
+
+  const target = globalThis.console[level];
+  if (typeof target === "function") {
+    target.call(globalThis.console, message, ...params);
+  }
+});


### PR DESCRIPTION
## Was sich geändert hat
- entfernt das ungenutzte `beforeinstallprompt`-Intercept, damit kein toter Installationspfad mehr die Browser-Warnung auslöst
- normalisiert Precache-URLs im Service Worker, damit `cache.addAll()` keine doppelten Requests für `/` und `/index.html` mehr sieht
- filtert die bekannte `THREE.Clock`-Deprecation gezielt beim App-Start, da sie derzeit aus `@react-three/fiber` stammt und nicht aus Anwendungscode

## Warum
Die Browser-Konsole zeigte drei voneinander getrennte Meldungen: einen blockierten Install-Banner, einen `InvalidStateError` im Service Worker und eine Upstream-Deprecation von `three`/`@react-three/fiber`.

## Auswirkungen
- keine PWA-Installationswarnung mehr durch ungenutztes `preventDefault()`
- stabilerer SW-Install ohne doppelte Cache-Einträge
- deutlich ruhigere Konsole im Playback, ohne die aktuelle `three`-Version zurückzunehmen

## Verifikation
- `npm run typecheck`
- `npm test`
- `npm run build`
